### PR TITLE
Feature: CloudsubscriptionID and DivisionID

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -43,7 +43,7 @@ type OrderDetails struct {
 		PONumber            string `json:"poNumber"`
 		FriendlyName        string `json:"friendlyName"`
 		PrincipalID         string `json:"principalId"`
-		CloudSubscriptionID string `json:"cloudSubscriptionId"`
+		CloudSubscriptionID *int   `json:"cloudSubscriptionId"`
 	} `json:"items"`
 }
 

--- a/client/subscriptions.go
+++ b/client/subscriptions.go
@@ -15,6 +15,7 @@ type SubscriptionDetails struct {
 	PrincipalID  string
 	PONumber     string
 	BudgetCode   string
+	DivisionID   int
 }
 
 // Basket Struct for Basket Post Request response
@@ -49,7 +50,7 @@ type BasketPayload struct {
 	PONumber     string `json:"poNumber"`
 	BillingFreq  string `json:"billingFrequency"`
 	Term         string `json:"term"`
-	DivisionID   string `json:"divisionId"`
+	DivisionID   *int   `json:"divisionId"`
 	BudgetCode   string `json:"budgetCode"`
 }
 
@@ -72,7 +73,7 @@ func (c *Client) createBasketHelper(friendlyName string, principalId string, poN
 		PONumber:     poNumber,
 		BillingFreq:  "monthly",
 		Term:         "Perpetual",
-		DivisionID:   "3565",
+		DivisionID:   nil,
 		BudgetCode:   budgetCode,
 	}
 	data, err := json.Marshal(payload)

--- a/client/subscriptions.go
+++ b/client/subscriptions.go
@@ -241,3 +241,42 @@ func (c *Client) CreateSubscription(details SubscriptionDetails) (*OrderDetails,
 
 	return subscriptionInfo, nil
 }
+
+func (c *Client) UpdateSubscription(subscriptionID string, details SubscriptionDetails) (*OrderDetails, error) {
+	url := fmt.Sprintf("%s/api/v2/subscriptions/%s", c.CommerceAPIURL, subscriptionID)
+
+	data, err := json.Marshal(details)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal payload: %s", err)
+	}
+
+	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %s", err)
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.CustomToken))
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.CustomHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %s", err)
+	}
+	defer res.Body.Close()
+
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %s", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected HTTP status code: %d, response body: %s", res.StatusCode, string(bodyBytes))
+	}
+
+	var order OrderDetails
+	err = json.Unmarshal(bodyBytes, &order)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body: %s", err)
+	}
+
+	return &order, nil
+}

--- a/docs/resources/subscription.md
+++ b/docs/resources/subscription.md
@@ -37,6 +37,7 @@ resource "bytes_subscription" "example" {
 ### Optional
 
 - `default_admin` (String) The default admin which is assigned to a newly created subscription
+- `division_id` (Integer) The division id within Bytes for billing (this can only be set at creation)
 
 ### Read-Only
 

--- a/subscriptions/resource_subscription.go
+++ b/subscriptions/resource_subscription.go
@@ -14,6 +14,7 @@ func resourceSubscription() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceSubscriptionCreate,
 		ReadContext:   resourceSubscriptionRead,
+		UpdateContext: resourceSubscriptionUpdate,
 		DeleteContext: resourceSubscriptionDelete,
 		Schema: map[string]*schema.Schema{
 			"id": {
@@ -58,7 +59,6 @@ func resourceSubscription() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    false,
-				ForceNew:    true,
 				Description: "The division ID to use for subscription billing",
 			},
 		},
@@ -109,11 +109,32 @@ func resourceSubscriptionCreate(ctx context.Context, d *schema.ResourceData, m i
 
 	return nil
 }
+
 func resourceSubscriptionRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 	return diags
 }
+
+func resourceSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.Client)
+
+	subscriptionDetails := client.SubscriptionDetails{
+		FriendlyName: d.Get("friendly_name").(string),
+		PONumber:     d.Get("po_number").(string),
+		PrincipalID:  d.Get("default_admin").(string),
+		BudgetCode:   d.Get("budget_code").(string),
+		DivisionID:   d.Get("division_id").(int),
+	}
+
+	_, err := c.UpdateSubscription(d.Id(), subscriptionDetails)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceSubscriptionRead(ctx, d, m)
+}
+
 func resourceSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// No-op, do nothing when deleting, not currently supported by Bytes API
 	return nil

--- a/subscriptions/resource_subscription.go
+++ b/subscriptions/resource_subscription.go
@@ -54,6 +54,13 @@ func resourceSubscription() *schema.Resource {
 				ForceNew:    true,
 				Description: "The budget code to use for subscription billing",
 			},
+			"division_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    false,
+				ForceNew:    true,
+				Description: "The division ID to use for subscription billing",
+			},
 		},
 		Description: "Creates a new Azure subscription.\n\n" +
 			"This resources is intended to be used to create a new Azure subscription",
@@ -71,6 +78,7 @@ func resourceSubscriptionCreate(ctx context.Context, d *schema.ResourceData, m i
 		PONumber:     d.Get("po_number").(string),
 		PrincipalID:  d.Get("default_admin").(string),
 		BudgetCode:   d.Get("budget_code").(string),
+		DivisionID:   d.Get("division_id").(int),
 	}
 
 	// Call the function create the subscription with payload


### PR DESCRIPTION
Fixed issue with the cloudSubscriptionID being a string instead needing to be a nullable integer. Switched division_id to nullable integer.

Feature: Created function to set division_id in the resource_subscription block. Added function to update subscription to retroactively update existing subscriptions division_id (currently not a feature in the bytes api) 